### PR TITLE
Added spike-in naming flexibility

### DIFF
--- a/D3ECmd.py
+++ b/D3ECmd.py
@@ -58,7 +58,7 @@ parser.add_argument('-t', '--test', action = 'store', type = int, dest = 'test',
 													'2: Anderson-Darling test\n')
 parser.add_argument('-n','--normalise', action = 'store', type = int, dest='normalise', default = 1, choices = [0,1], help='Normalise the data')
 parser.add_argument('-z', '--removeZeros', action = 'store', type = int, dest='removeZeros', default = 0, choices = [0,1], help='Remove zeros')
-parser.add_argument('-s', '--useSpikeIns', action = 'store', type = int, dest='useSpikeIns', default = 0, choices = [0,1], help='Use spike-ins for normalisation. Requires at least one row with id starting with "spike" ')
+parser.add_argument('-s', '--useSpikeIns', action = 'store', type = int, dest='useSpikeIns', default = 0, choices = [0,1], help='Use spike-ins for normalisation. Requires at least one row with id starting with "spike" or the string set with --spikeInStart ')
 parser.add_argument('--spikeInStart', action = 'store', type = str, nargs = 1, dest = 'spikeInStart', default = 'spike', help = 'A string to identify spike-ins. (spike)', metavar = 'spike')
 parser.add_argument('-v', action = 'store_const', const = True, dest = 'verbose', default = True, help = 'verbose')
 args = parser.parse_args()

--- a/D3ECmd.py
+++ b/D3ECmd.py
@@ -59,7 +59,7 @@ parser.add_argument('-t', '--test', action = 'store', type = int, dest = 'test',
 parser.add_argument('-n','--normalise', action = 'store', type = int, dest='normalise', default = 1, choices = [0,1], help='Normalise the data')
 parser.add_argument('-z', '--removeZeros', action = 'store', type = int, dest='removeZeros', default = 0, choices = [0,1], help='Remove zeros')
 parser.add_argument('-s', '--useSpikeIns', action = 'store', type = int, dest='useSpikeIns', default = 0, choices = [0,1], help='Use spike-ins for normalisation. Requires at least one row with id starting with "spike" ')
-parser.add_argument('--spikeInStart', action = 'store', type = str, nargs = 1, dest = 'spikeInStart', default = 'spike', help = 'A string to identify spike-ins.')
+parser.add_argument('--spikeInStart', action = 'store', type = str, nargs = 1, dest = 'spikeInStart', default = 'spike', help = 'A string to identify spike-ins. (spike)', metavar = 'spike')
 parser.add_argument('-v', action = 'store_const', const = True, dest = 'verbose', default = True, help = 'verbose')
 args = parser.parse_args()
 

--- a/D3ECmd.py
+++ b/D3ECmd.py
@@ -59,10 +59,11 @@ parser.add_argument('-t', '--test', action = 'store', type = int, dest = 'test',
 parser.add_argument('-n','--normalise', action = 'store', type = int, dest='normalise', default = 1, choices = [0,1], help='Normalise the data')
 parser.add_argument('-z', '--removeZeros', action = 'store', type = int, dest='removeZeros', default = 0, choices = [0,1], help='Remove zeros')
 parser.add_argument('-s', '--useSpikeIns', action = 'store', type = int, dest='useSpikeIns', default = 0, choices = [0,1], help='Use spike-ins for normalisation. Requires at least one row with id starting with "spike" ')
+parser.add_argument('--spikeInStart', action = 'store', type = str, nargs = 1, dest = 'spikeInStart', default = 'spike', help = 'A string to identify spike-ins.')
 parser.add_argument('-v', action = 'store_const', const = True, dest = 'verbose', default = True, help = 'verbose')
 args = parser.parse_args()
 
-data1, data2, ids, lineStatus = readData(args.inputFile, args.label1[0], args.label2[0], args.normalise, args.removeZeros, args.useSpikeIns)
+data1, data2, ids, lineStatus = readData(args.inputFile, args.label1[0], args.label2[0], args.normalise, args.removeZeros, args.useSpikeIns, args.spikeInStart)
 
 if args.verbose:
 	for status in lineStatus:

--- a/D3EUtil.py
+++ b/D3EUtil.py
@@ -147,7 +147,7 @@ def _normalisationWeights(data):
 	return weights
 
 # Read input data file, extract read counts, normalise, report errors
-def readData(inputFile, label1, label2, normalise=True, removeZeros=False, useSpikeIns = False, verbose = False):
+def readData(inputFile, label1, label2, normalise=True, removeZeros=False, useSpikeIns = False, verbose = False, spikeInStart = 'spike'):
 
 	data1 = []
 	data2 = []
@@ -189,7 +189,7 @@ def readData(inputFile, label1, label2, normalise=True, removeZeros=False, useSp
 				lineStatus.append( Status(0, idx,  "Line read OK") )
 
 
-			if idx.lower().startswith('spike'):
+			if idx.lower().startswith(spikeInStart):
 				spikeIns.append( p1 + p2 )
 				lineStatus.append( Status(0, idx,  "Spike-in detected") )
 				continue


### PR DESCRIPTION
Hi @mdelmans,

I just added a bit of flexibility with the spike-in naming scheme. Therefore, I created a new parameter --spikeInStart, with which the user can give a string that identifies the spike-in. The default is still "spike", so running code should still work.

Best,
Jens
